### PR TITLE
Remove the api key from repo and setup backend connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ testem.log
 /typings
 .env
 
+# Environment specific secrets
+
 # System files
 .DS_Store
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -15,6 +15,37 @@ ng serve
 
 Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
 
+## Map Tiles Configuration
+
+TrackOSS now relies on a backend service to securely provide map tiles. The API key for the map tile service (e.g., MapTiler) is managed by this backend, not directly in the frontend application.
+
+**Backend Setup:**
+
+You will need to set up and run the corresponding backend service. Detailed instructions for setting up the Spring Boot backend proxy are provided separately (refer to project documentation or previous communications if this README is part of the frontend-only repository).
+
+**Frontend Configuration:**
+
+The frontend application is configured to connect to this backend service. The URLs are defined in:
+- `src/environments/environments.ts` for development (defaults to `http://localhost:8080/api/tiles`)
+- `src/environments/environment.prod.ts` for production (defaults to `/api/tiles`, assuming same-domain deployment or reverse proxy setup)
+
+If your backend runs on a different URL during development or in production, you'll need to update these configuration files accordingly. For example, to change the development backend URL:
+
+Modify `src/environments/environments.ts`:
+```typescript
+export const environment = {
+  production: false,
+  // Update this URL to where your backend is running
+  mapTileProxyBaseUrl: 'http://your-backend-host:your-backend-port/api/tiles',
+};
+```
+
+**Running the Application:**
+
+1.  Ensure your backend service is running and accessible.
+2.  Run the Angular development server: `ng serve`.
+3.  Open your browser to `http://localhost:4200/`.
+
 ## Code scaffolding
 
 Angular CLI includes powerful code scaffolding tools. To generate a new component, run:

--- a/src/app/libre-map/libre-map.component.ts
+++ b/src/app/libre-map/libre-map.component.ts
@@ -22,7 +22,7 @@ export interface Coordinates { // Exporting for potential use elsewhere
   standalone: true,
 })
 export class LibreMapComponent implements OnInit, OnChanges { // Implement OnChanges
-  mapStyleUrl: string = `https://api.maptiler.com/maps/outdoor/style.json?key=${environment.maptileApiKey}`;
+  mapStyleUrl: string = `${environment.mapTileProxyBaseUrl}/style.json`;
   public map?: Map; // map property should be public if accessed from template, or use onMapLoad
   // startPosition is used for initial map center if no points are provided.
   startPosition: [number, number] = [13.404954, 52.520008]; // Berlin coordinates

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  mapTileProxyBaseUrl: '/api/tiles', // Placeholder: User should configure this to their actual backend URL in production
+};

--- a/src/environments/environments.ts
+++ b/src/environments/environments.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  maptileApiKey: '1lm1yVfqIb88hvtSkptP',
+  mapTileProxyBaseUrl: 'http://localhost:8080/api/tiles', // URL for local Spring Boot backend
 };


### PR DESCRIPTION
To remove the api key from the frontend, we will proxy the map from the backend